### PR TITLE
Update google-forms-css.js

### DIFF
--- a/google-forms-css/google-forms-css.js
+++ b/google-forms-css/google-forms-css.js
@@ -5,6 +5,14 @@
 
 */
 
+// Function to extract json form object
+function getForm(indata) {
+  var rx = /var FB_PUBLIC_LOAD_DATA_ =(.*\d\]);\n?<\/script>/g;
+  var arr = rx.exec(indata);
+  return arr[1]; 
+}
+
+
 var googleFormsCSS = function(params) {
 
   // jquery
@@ -29,14 +37,7 @@ var googleFormsCSS = function(params) {
     //
 
     // form data
-    var needle = 'var FB_PUBLIC_LOAD_DATA_ = ';
-    var start = data.indexOf(needle);
-    if (start === -1) {
-      console.error('google-forms-css > form data not found');
-      return;
-    }
-    var end = data.indexOf(';', start);
-    var json = data.substring(start + needle.length, end);
+    var json = getForm(data)
     var formData = JSON.parse(json);
 
     // items

--- a/google-forms-css/google-forms-css.js
+++ b/google-forms-css/google-forms-css.js
@@ -7,7 +7,7 @@
 
 // Function to extract json form object
 function getForm(indata) {
-  var rx = /var FB_PUBLIC_LOAD_DATA_ =(.*\d\]);\n?<\/script>/g;
+  var rx = /var FB_PUBLIC_LOAD_DATA_ =(.*);\n?<\/script>/g;
   var arr = rx.exec(indata);
   return arr[1]; 
 }


### PR DESCRIPTION
Fixed flaky extraction (broken in some recent gforms). Used regex to extract json object instead of existing method (string splice).

Although this has been working fine, recently a form returned `1];` instead of `0];` in the JSON object, breaking the existing check. I've genericised this somewhat using a regex (although admittedly it's still flaky).

I know this project hasn't been updated in 7 years, but hey. May as well put this out there for someone else who may have the same issue!